### PR TITLE
Separate liberty:package config into -PlibertyPackage profile

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -48,23 +48,40 @@
       <plugin>
         <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <version>3.9</version>
+        <version>3.10</version>
         <configuration>
           <!-- tag::appsDirectory[] -->
           <appsDirectory>apps</appsDirectory>
           <!-- end::appsDirectory[] -->
-          <!-- tag::installAppPackages[] -->
-          <installAppPackages>spring-boot-project</installAppPackages>
-          <!-- end::installAppPackages[] -->
-          <!-- tag::include[] -->
-          <include>minify,runnable</include>
-          <!-- end::include[] -->
-          <!-- tag::packageFile[] -->
-          <packageName>GSSpringBootApp</packageName>
-          <!-- end::packageFile[] -->
+          <!-- tag::deployPackages[] -->
+          <deployPackages>spring-boot-project</deployPackages>
+          <!-- end::deployPackages[] -->
+          
         </configuration>
-        <!-- tag::packageGoals[] -->
-        <executions>
+
+      </plugin>
+      <!-- end::libertyMavenPlugin[] -->
+      <!-- End of Liberty Maven plugin -->
+
+        </plugins>
+    </build>
+<profiles>
+    <profile>
+      <id>libertyPackage</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+
+
+      <build>
+        <plugins>
+        <!-- Enable liberty-maven plugin -->
+          <plugin>
+            <groupId>io.openliberty.tools</groupId>
+            <artifactId>liberty-maven-plugin</artifactId>
+
+            <version>3.10</version>
+            <executions>        	
           <execution>
             <id>package-server</id>
             <phase>package</phase>
@@ -74,14 +91,21 @@
               <goal>deploy</goal>
               <goal>package</goal>
             </goals>
-          </execution>
-        </executions>
-        <!-- end::packageGoals[] -->
-      </plugin>
-      <!-- end::libertyMavenPlugin[] -->
-      <!-- End of Liberty Maven plugin -->
-
-        </plugins>
-    </build>
-
+            
+            <configuration>
+              <!-- tag::include[] -->
+              <include>minify,runnable</include>
+              <!-- end::include[] -->
+              <!-- tag::packageName[] -->
+              <packageName>GSSpringBootApp</packageName>
+              <!-- end::packageName[] -->
+            </configuration>
+           </execution>     
+         </executions>
+        </plugin>
+       </plugins>
+     </build>
+    </profile>
+  </profiles>
 </project>
+	


### PR DESCRIPTION
I think the way this guide binds the liberty:package goal to the package phase, in order to build a runnable server JAR detracts from the developer experience, so let me propose a bit of a rework.

The quickest way to take a SpringBoot sample and run it on Liberty is to do:
> mvn package liberty:run

You only have to provide a server.xml and configure liberty-maven-plugin to use `<deployPackages>spring-boot-project</deployPackages>`.   

You could even do it all with:
 > mvn package liberty:run -DdeployPackages=spring-boot-project  -Dtemplate=springBoot3
though that's a bit more to remember.

This isn't all that much more than you'd need to use the spring-boot Maven plugin, where you could just do:
> mvn spring-boot:run    

We can take the parts that build a runnable JAR and refactor them into a profile.

So if we run down three ways of executing

1.  java -jar  
We made this a bit harder... instead of `mvn package; java -jar target/xyz.jar`  we now have a more custom build cmd, you have to enable a profile
2. Docker
We made the `mvn package && docker build` just a bit quicker, since we don't use the runnable JAR at all to build the Docker image
3. mvn
We made this a bit 


### OTHER THOUGHTS

1.  Should liberty:deploy just do the package/repackage of a non-loose app?  Should liberty:run do all these SB related goals:   spring-boot:test  jar:jar spring-boot:repackage?

2. If we had the "skipServerStart" from https://github.com/OpenLiberty/ci.maven/issues/739 we could do more like:
- mvn package liberty:run -DskipServerStart liberty:package without having to configure the liberty:package goal in the POM, even a profile.  (And if we added more to the 'deploy' goal and/or 'run' goals as mentioned above we wouldn't need to run the 'package' phase.






If we agree on this we can update the guide doc.  